### PR TITLE
KOGITO-5920: avoid duplicate context exp names

### DIFF
--- a/packages/boxed-expression-component/src/api/Table.ts
+++ b/packages/boxed-expression-component/src/api/Table.ts
@@ -57,7 +57,7 @@ export interface TableProps {
   /** Function to be executed when one or more rows are modified */
   onRowsUpdate?: (args: RowsUpdateArgs) => void;
   /** Function to be executed when adding a new row to the table */
-  onRowAdding?: (existingRowsCount: number) => DataRecord;
+  onRowAdding?: (allRows: DataRecord[]) => DataRecord;
   /** Custom configuration for the table handler */
   handlerConfiguration?: TableHandlerConfiguration;
   /** The way in which the header will be rendered */

--- a/packages/boxed-expression-component/src/components/ContextExpression/ContextExpression.tsx
+++ b/packages/boxed-expression-component/src/components/ContextExpression/ContextExpression.tsx
@@ -50,6 +50,7 @@ const DEFAULT_CONTEXT_ENTRY_NAME = "ContextEntry-1";
 const DEFAULT_CONTEXT_ENTRY_DATA_TYPE = DataType.Undefined;
 
 export const ContextExpression: React.FunctionComponent<ContextProps> = (contextExpression: ContextProps) => {
+  const existingEntryInfos: EntryInfo[] = [];
   const { i18n } = useBoxedExpressionEditorI18n();
   const { setSupervisorHash, boxedExpressionEditorGWTService, decisionNodeId } = useBoxedExpression();
 
@@ -179,13 +180,12 @@ export const ContextExpression: React.FunctionComponent<ContextProps> = (context
   );
 
   const onRowAdding = useCallback(
-    (existingRowsCount: number) => {
-      const generatedName = generateNextAvailableEntryName(
-        _.map(rows, (row: ContextEntryRecord) => row.entryInfo) as EntryInfo[],
-        "ContextEntry",
-        existingRowsCount + 1
-      );
-      return {
+    (allRows: DataRecord[]) => {
+      if (!existingEntryInfos.length) {
+        existingEntryInfos.push(...(_.map(allRows, (row: ContextEntryRecord) => row.entryInfo) as EntryInfo[]));
+      }
+      const generatedName = generateNextAvailableEntryName(existingEntryInfos, "ContextEntry");
+      const row = {
         entryInfo: {
           id: generateUuid(),
           name: generatedName,
@@ -198,8 +198,12 @@ export const ContextExpression: React.FunctionComponent<ContextProps> = (context
         editInfoPopoverLabel: i18n.editContextEntry,
         nameAndDataTypeSynchronized: true,
       };
+
+      existingEntryInfos.push(row.entryInfo);
+
+      return row;
     },
-    [i18n.editContextEntry, rows]
+    [i18n.editContextEntry]
   );
 
   const onRowsUpdate = useCallback(

--- a/packages/boxed-expression-component/src/components/Table/Table.tsx
+++ b/packages/boxed-expression-component/src/components/Table/Table.tsx
@@ -147,12 +147,9 @@ export const Table: React.FunctionComponent<TableProps> = ({
   const tableEventUUID = useMemo(() => `table-event-${uuid()}`, []);
   const boxedExpression = useBoxedExpression();
 
-  const onRowAddingCallback = useCallback(
-    (existingRowsCount: number) => {
-      return onRowAdding ? onRowAdding(existingRowsCount) : {};
-    },
-    [onRowAdding]
-  );
+  const onRowAddingCallback = useCallback(() => {
+    return onRowAdding ? onRowAdding(tableRows.current) : {};
+  }, [onRowAdding]);
   const onGetColumnPrefix = useCallback(
     (groupType?: string) => (getColumnPrefix ? getColumnPrefix(groupType) : "column-"),
     [getColumnPrefix]

--- a/packages/boxed-expression-component/src/components/Table/common/CopyAndPasteUtils.ts
+++ b/packages/boxed-expression-component/src/components/Table/common/CopyAndPasteUtils.ts
@@ -71,7 +71,7 @@ export const paste = (pasteValue: string, reference: Element, editorElement: HTM
 export const pasteOnTable = (
   pasteValue: string,
   rows: DataRecord[],
-  rowFactory: (existingRowsCount: number) => DataRecord,
+  rowFactory: () => DataRecord,
   x: number = 0,
   y: number = 0
 ): DataRecord[] => {
@@ -106,7 +106,7 @@ export const pasteOnTable = (
     const row = paste[i];
 
     if (i + y >= newRows.length) {
-      newRows.push(rowFactory(newRows.length));
+      newRows.push(rowFactory());
     }
 
     for (let j = 0; j < row.length; j++) {


### PR DESCRIPTION
@jomarko 

To check for Context Expression names to exist we need to take the updated rows from the `Table` component as the `onRowAdding` event of `ContextExpression` is called before its update and doesn't automatically have the updated rows.

Please feel free to change it.