### PR TITLE
Check for differences to force a re-render

### DIFF
--- a/packages/online-editor/package.json
+++ b/packages/online-editor/package.json
@@ -59,6 +59,7 @@
     "@patternfly/react-tokens": "^4.94.6",
     "bowser": "^2.10.0",
     "buffer": "^6.0.3",
+    "deep-object-diff": "^1.1.9",
     "history": "^4.9.0",
     "isomorphic-git": "^1.11.1",
     "js-yaml": "^4.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5175,6 +5175,9 @@ importers:
       buffer:
         specifier: ^6.0.3
         version: 6.0.3
+      deep-object-diff:
+        specifier: ^1.1.9
+        version: 1.1.9
       history:
         specifier: ^4.9.0
         version: 4.10.1


### PR DESCRIPTION
Please, consider the following scenario:

https://github.com/jomarko/kie-tools/assets/24302289/ddf71d8e-551d-4a32-8d03-ef3a4e04bff1

Currently, `uniforms` doesn't re-render after the JSON Schema is updated, this way, we need to **force** a re-render. The "forceDmnRunnerRerender" call wasn't in the right place, skiping the `x-dmn-allowed-values` case.